### PR TITLE
Fixed the issue of no settings menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/syt2/zotero-scipdf#readme",
   "dependencies": {
-    "zotero-plugin-toolkit": "^2.3.25"
+    "zotero-plugin-toolkit": "^4.0.6"
   },
   "devDependencies": {
     "@types/node": "^20.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { BasicTool } from "zotero-plugin-toolkit/dist/basic";
+import { BasicTool } from "zotero-plugin-toolkit";
 import Addon from "./addon";
 import { config } from "../package.json";
 

--- a/src/modules/Common.ts
+++ b/src/modules/Common.ts
@@ -10,7 +10,8 @@ export class Common {
       image: `chrome://${config.addonRef}/content/icons/sci-hub-logo.svg`,
       defaultXUL: true,
     };
-    ztoolkit.PreferencePane.register(prefOptions);
+    ztoolkit.getGlobal("Zotero").PreferencePanes.register(prefOptions);
+    // ztoolkit.PreferencePane.register(prefOptions);
   }
 
   // // register an item in menu tools

--- a/src/modules/CustomResolverManager.ts
+++ b/src/modules/CustomResolverManager.ts
@@ -1,4 +1,4 @@
-import { LargePrefHelper } from "zotero-plugin-toolkit/dist/helpers/largePref";
+import { LargePrefHelper } from "zotero-plugin-toolkit";
 import { config } from "../../package.json";
 import { CustomResolver, isCustomResolverEqual } from "./CustomResolver";
 

--- a/src/utils/ztoolkit.ts
+++ b/src/utils/ztoolkit.ts
@@ -1,4 +1,4 @@
-import ZoteroToolkit from "zotero-plugin-toolkit";
+import { ZoteroToolkit } from "zotero-plugin-toolkit";
 import { config } from "../../package.json";
 
 export { createZToolkit };
@@ -29,9 +29,9 @@ function initZToolkit(_ztoolkit: ReturnType<typeof createZToolkit>) {
   // );
 }
 
-import { BasicTool, unregister } from "zotero-plugin-toolkit/dist/basic";
+import { BasicTool, unregister } from "zotero-plugin-toolkit";
 // import { UITool } from "zotero-plugin-toolkit/dist/tools/ui";
-import { PreferencePaneManager } from "zotero-plugin-toolkit/dist/managers/preferencePane";
+// import { PreferencePaneManager } from "zotero-plugin-toolkit/dist/managers/preferencePane";
 
 class MyToolkit extends BasicTool {
 


### PR DESCRIPTION
upgrade zotero-plugin-toolkit version,Fixed the issue of no settings menu
升级zotero-plugin-toolkit版本，修复没有设置菜单的问题。

参考: 
https://github.com/windingwind/zotero-plugin-toolkit/issues/64#issuecomment-2392558295

