### PR TITLE
New selector

### DIFF
--- a/src/modules/CustomResolver.ts
+++ b/src/modules/CustomResolver.ts
@@ -46,10 +46,10 @@ export function sciHubCustomResolver(url: string, automatic = true): CustomResol
 
 export function presetSciHubCustomResolvers(automatic = true): Readonly<Readonly<CustomResolver>[]> {
   const scihubURLs = [
-    'https://sci-hub.se/',
+    'https://sci-hub.box/',
     'https://sci-hub.st/',
     'https://sci-hub.ru/',
-    'https://sci-hub.box/',
+    'https://sci-hub.se/',
     'https://sci-hub.red/',
     'https://sci-hub.ren/',
     'https://sci-hub.ee/',


### PR DESCRIPTION
Sci-hub changed their layout, adapted the selector to catch the download button instead. Changed url order as well, .box and .st seem to be the most reliable.

<img width="315" height="237" alt="new-scihub-layout" src="https://github.com/user-attachments/assets/5c7ffc8a-4a16-4522-a68e-a71e74f67544" />
