### PR TITLE
Update zh-TW localization

### DIFF
--- a/addon/locale/zh-TW/addon.ftl
+++ b/addon/locale/zh-TW/addon.ftl
@@ -1,0 +1,10 @@
+prefs-title = PDF下載
+menuitem-fetch = 獲取PDF
+collectionmenuitem-fetch = 獲取PDF
+menutoolsitem-fetchall = 獲取所有項目的PDF
+popwin-fetching = 獲取中
+popwin-fetchsuccess = 下載成功
+popwin-doimissing = DOI未找到
+popwin-pdfnotavaliable = PDF未找到
+popwin-unknownerror = 未知錯誤
+popwin-unknownerrorclick= 點擊前往Sci-Hub

--- a/addon/locale/zh-TW/preferences.ftl
+++ b/addon/locale/zh-TW/preferences.ftl
@@ -1,0 +1,5 @@
+pref-title = PDF Download
+pref-autoDownload =
+    .label = 自動下載PDF
+pref-scihub-input = Scihub URL:
+pref-help = { $name } Build { $version }


### PR DESCRIPTION
## Proposed Changes

Add zh-TW (Traditional Chinese) localization files.

## NOTE

This zh-TW localization is based on the zh-CN localization included in this repository (shipped with the mod/project), converted and polished for Traditional Chinese usage while preserving the original intent. 