### PR TITLE
[codex] Adapt plugin for Zotero 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,32 @@
 # SciPDF For Zotero
 
-[![zotero target version](https://img.shields.io/badge/Zotero-7+-green?style=flat-square&logo=zotero&logoColor=CC2936)](https://www.zotero.org)
+[![zotero target version](https://img.shields.io/badge/Zotero-9-green?style=flat-square&logo=zotero&logoColor=CC2936)](https://www.zotero.org)
 [![Using Zotero Plugin Template](https://img.shields.io/badge/Using-Zotero%20Plugin%20Template-blue?style=flat-square&logo=github)](https://github.com/windingwind/zotero-plugin-template)
 
 English | [简体中文](doc/README-zhCN.md)
 
-
 # Introduction
-This is a Sci-Hub plugin designed for Zotero 7 and Zotero 8.  
+
+This is a Sci-Hub plugin adapted for Zotero 9.
 This plugin utilizes Zotero's built-in [PDF resolvers](https://www.zotero.org/support/kb/custom_pdf_resolvers) feature.  
 It automatically writes Sci-Hub's resolver into the `extensions.zotero.findPDFs.resolvers` field and enabling automatic PDF downloads from Sci-Hub within Zotero.
 
 > [Detail code in Zotero](https://github.com/zotero/zotero/blob/5536f8d2bd08ddac9074b9df05b7d205273835e7/chrome/content/zotero/xpcom/attachments.js#L1350)  
 > [Custom PDF resolvers](https://www.zotero.org/support/kb/custom_pdf_resolvers)  
-> [Zotero Chinese user guide](https://zotero-chinese.com/user-guide/plugins/Zotero-scihub.html#操作步骤)  
+> [Zotero Chinese user guide](https://zotero-chinese.com/user-guide/plugins/Zotero-scihub.html#操作步骤)
 
 # Usage
+
 Download and install the [latest release xpi file](https://github.com/syt2/zotero-scipdf/releases/latest/download/sci-pdf.xpi).
 
 - For items missing attachments prior to the installation of the plugin, right-click on the item and click on `Find Full Text`.
 - For newly added items with a `DOI`, if the `Automatically download PDFs` option is enabled in the preferences, Zotero will attempt to download the attachments automatically.
 
 ### Add/Remove Sci-Hub Sites
+
 Upon first installation, the plugin will come pre-configured with some common Sci-Hub sites. If you need to add other Sci-Hub sites or remove existing ones, you can edit them in the plugin's settings. Different sites can be separated by commas `,`.
 
 # FAQs
+
 - Items missing a `DOI` do not have the "Find Full Text" option and cannot be downloaded via Sci-Hub.
 - Items that already have associated attachments do not have the `Find Full Text` option.

--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -1,21 +1,36 @@
 <linkset>
   <html:link rel="localization" href="__addonRef__-preferences.ftl" />
 </linkset>
-<vbox id="zotero-prefpane-__addonRef__" onload="Zotero.__addonInstance__.hooks.onPrefsEvent('load', {window})">
+<vbox
+  id="zotero-prefpane-__addonRef__"
+  onload="SciPDF_Preferences.init(window)"
+>
   <groupbox>
     <label>
       <html:h2 data-l10n-id="pref-title"></html:h2>
     </label>
 
-    <checkbox id="zotero-prefpane-__addonRef__-autoDownload" data-l10n-id="pref-autoDownload" />
+    <checkbox
+      id="zotero-prefpane-__addonRef__-autoDownload"
+      data-l10n-id="pref-autoDownload"
+    />
 
     <hbox>
-      <html:label for="zotero-prefpane-__addonRef__-scihubUrl" data-l10n-id="pref-scihub-input"></html:label>
-      <html:input type="text" id="zotero-prefpane-__addonRef__-scihubUrl"></html:input>
+      <html:label
+        for="zotero-prefpane-__addonRef__-scihubUrl"
+        data-l10n-id="pref-scihub-input"
+      ></html:label>
+      <html:input
+        type="text"
+        id="zotero-prefpane-__addonRef__-scihubUrl"
+      ></html:input>
     </hbox>
   </groupbox>
 </vbox>
 <vbox>
-  <html:label data-l10n-id="pref-help" data-l10n-args='{"name": "__addonName__","version":"__buildVersion__"}'>
+  <html:label
+    data-l10n-id="pref-help"
+    data-l10n-args='{"name": "__addonName__","version":"__buildVersion__"}'
+  >
   </html:label>
 </vbox>

--- a/addon/content/scripts/preferences.js
+++ b/addon/content/scripts/preferences.js
@@ -1,0 +1,7 @@
+var SciPDF_Preferences = {
+  init(win) {
+    return Zotero.__addonInstance__.hooks.onPrefsEvent("load", {
+      window: win || window,
+    });
+  },
+};

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -13,7 +13,7 @@
     "zotero": {
       "id": "__addonID__",
       "update_url": "__updateURL__",
-      "strict_min_version": "6.999",
+      "strict_min_version": "9.0",
       "strict_max_version": "9.*"
     }
   }

--- a/doc/README-zhCN.md
+++ b/doc/README-zhCN.md
@@ -1,27 +1,31 @@
 # SciPDF For Zotero
 
-[![zotero target version](https://img.shields.io/badge/Zotero-7+-green?style=flat-square&logo=zotero&logoColor=CC2936)](https://www.zotero.org)
+[![zotero target version](https://img.shields.io/badge/Zotero-9-green?style=flat-square&logo=zotero&logoColor=CC2936)](https://www.zotero.org)
 [![Using Zotero Plugin Template](https://img.shields.io/badge/Using-Zotero%20Plugin%20Template-blue?style=flat-square&logo=github)](https://github.com/windingwind/zotero-plugin-template)
 
 [English](../README.md) | 简体中文
 
 # 介绍
-这是一个用于 Zotero7 和 Zotero8 的 Sci-Hub 插件。  
+
+这是一个适配 Zotero 9 的 Sci-Hub 插件。
 此插件利用了 Zotero 内自带的 [PDF resolvers](https://www.zotero.org/support/kb/custom_pdf_resolvers)方案，将 Sci-Hub 的 resolver 自动填入 `extensions.zotero.findPDFs.resolvers` 字段，以实现在zotero内从sci-hub下载pdf。
 
 > [Zotero代码](https://github.com/zotero/zotero/blob/5536f8d2bd08ddac9074b9df05b7d205273835e7/chrome/content/zotero/xpcom/attachments.js#L1350)  
 > [自定义PDF resolvers](https://www.zotero.org/support/kb/custom_pdf_resolvers)  
-> [Zotero中文社区相关信息](https://zotero-chinese.com/user-guide/plugins/Zotero-scihub.html#操作步骤)  
+> [Zotero中文社区相关信息](https://zotero-chinese.com/user-guide/plugins/Zotero-scihub.html#操作步骤)
 
 # 使用
+
 下载并安装[最新版插件](https://github.com/syt2/zotero-scipdf/releases/latest/download/zotero-scipdf.xpi)。
 
 - 对于安装插件前已经缺失附件的item，右键该item，点击`查找全文`即可
 - 对于新增的带有`DOI`的条目，如果在首选项内勾选了`自动下载PDF`选项，则Zotero会自动尝试下载附件
 
 ### 增加/删除Sci-Hub站点
+
 首次安装时插件会内置部分常用的Sci-Hub站点，若需要添加其他Sci-Hub站点，或删除已有Sci-Hub站点的，可以在插件的设置界面内编辑，不同的站点以`,`或`，`分割
 
 # 常见问题
+
 - 缺失`DOI`的条目没有`查找全文`选项，也无法通过scihub下载
 - 已经关联了附件的条目没有`查找全文`选项

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -18,6 +18,7 @@ class Addon {
       window: Window;
     };
     dialog?: DialogHelper;
+    registeredMenuIDs: string[];
   };
   // Lifecycle hooks
   public hooks: typeof hooks;
@@ -31,6 +32,7 @@ class Addon {
       env: __env__,
       initialized: false,
       ztoolkit: createZToolkit(),
+      registeredMenuIDs: [],
     };
     this.hooks = hooks;
     this.api = {};

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,7 +2,11 @@ import { getString, initLocale } from "./utils/locale";
 import { registerPrefsScripts } from "./modules/preferenceScript";
 import { createZToolkit } from "./utils/ztoolkit";
 import { getPref, setPref } from "./utils/prefs";
-import { sciHubCustomResolver, presetSciHubCustomResolvers } from "./modules/CustomResolver";
+import {
+  sciHubCustomResolver,
+  presetSciHubCustomResolvers,
+  isObsoleteDefaultSciHubResolver,
+} from "./modules/CustomResolver";
 import { CustomResolverManager } from "./modules/CustomResolverManager";
 import { Common } from "./modules/Common";
 
@@ -15,6 +19,9 @@ async function onStartup() {
 
   initLocale();
 
+  CustomResolverManager.shared.removeCustomResolversMatching(
+    isObsoleteDefaultSciHubResolver,
+  );
 
   if (!getPref("firstInstall")) {
     setPref("firstInstall", true);
@@ -23,17 +30,21 @@ async function onStartup() {
     if (Zotero.Prefs.get("zoteroscihub.automatic_pdf_download")) {
       autoDownload = true;
     }
-    if (url && typeof url === 'string') {
+    if (url && typeof url === "string") {
       const resolver = sciHubCustomResolver(url, autoDownload);
       CustomResolverManager.shared.appendCustomResolversInZotero([resolver]);
     } else {
-      CustomResolverManager.shared.appendCustomResolversInZotero(presetSciHubCustomResolvers(true));
+      CustomResolverManager.shared.appendCustomResolversInZotero(
+        presetSciHubCustomResolvers(true),
+      );
     }
   } else {
-    CustomResolverManager.shared.appendCustomResolversInZotero(presetSciHubCustomResolvers(true));
+    CustomResolverManager.shared.appendCustomResolversInZotero(
+      presetSciHubCustomResolvers(true),
+    );
   }
 
-  Common.registerPrefs();
+  await Common.registerPrefs();
 
   await Promise.all(
     Zotero.getMainWindows().map((win) => onMainWindowLoad(win)),
@@ -57,6 +68,7 @@ async function onMainWindowUnload(win: Window): Promise<void> {
 }
 
 function onShutdown(): void {
+  Common.unregisterMenus();
   ztoolkit.unregisterAll();
   addon.data.dialog?.window?.close();
   // Remove addon object
@@ -64,7 +76,6 @@ function onShutdown(): void {
   // @ts-expect-error - Plugin instance is not typed
   delete Zotero[addon.data.config.addonInstance];
 }
-
 
 /**
  * This function is just an example of dispatcher for Preference UI events.

--- a/src/modules/Common.ts
+++ b/src/modules/Common.ts
@@ -3,19 +3,70 @@ import { getString } from "../utils/locale";
 import { SciHubFetcher } from "./SciHubFetcher";
 
 export class Common {
-  static registerPrefs() {
+  private static readonly itemMenuID = "scipdf-itemmenu-scihub-fetch";
+
+  private static applyMenuItemIcon(menuElem: XULElement, icon: string) {
+    if (Zotero.isMac) {
+      return;
+    }
+    menuElem.classList.add("menuitem-iconic");
+    menuElem.setAttribute("image", icon);
+    menuElem.style.setProperty("list-style-image", `url(${icon})`);
+  }
+
+  static async registerPrefs() {
     const prefOptions = {
       pluginID: config.addonID,
-      src: rootURI + "content/preferences.xhtml",
+      src: "content/preferences.xhtml",
       label: getString("prefs-title"),
-      image: `chrome://${config.addonRef}/content/icons/sci-hub-logo.svg`,
+      image: "content/icons/sci-hub-logo.svg",
+      scripts: ["content/scripts/preferences.js"],
       defaultXUL: true,
     };
-    ztoolkit.getGlobal("Zotero").PreferencePanes.register(prefOptions);
+    await ztoolkit.getGlobal("Zotero").PreferencePanes.register(prefOptions);
   }
 
   static registerRightClickMenuItem() {
     const menuIcon = `chrome://${config.addonRef}/content/icons/sci-hub-logo.svg`;
+    if (Zotero.MenuManager) {
+      if (addon.data.registeredMenuIDs.includes(this.itemMenuID)) {
+        return;
+      }
+      const registeredMenuID = Zotero.MenuManager.registerMenu({
+        menuID: this.itemMenuID,
+        pluginID: config.addonID,
+        target: "main/library/item",
+        menus: [
+          {
+            menuType: "menuitem",
+            icon: menuIcon,
+            onShowing: (_event, context) => {
+              context.menuElem.setAttribute(
+                "label",
+                getString("menuitem-fetch"),
+              );
+              context.setIcon(menuIcon);
+              Common.applyMenuItemIcon(context.menuElem, menuIcon);
+              const items =
+                context.items ??
+                Zotero.getActiveZoteroPane().getSelectedItems();
+              context.setVisible(items.some((item) => item.isRegularItem()));
+            },
+            onCommand: (_event, context) => {
+              const items =
+                context.items ??
+                Zotero.getActiveZoteroPane().getSelectedItems();
+              SciHubFetcher.updateItems(items, false);
+            },
+          },
+        ],
+      });
+      if (registeredMenuID) {
+        addon.data.registeredMenuIDs.push(registeredMenuID);
+      }
+      return;
+    }
+
     ztoolkit.Menu.register("item", {
       tag: "menuitem",
       id: "zotero-itemmenu-scihub-fetch",
@@ -30,5 +81,12 @@ export class Common {
       },
       icon: menuIcon,
     });
+  }
+
+  static unregisterMenus() {
+    for (const menuID of addon.data.registeredMenuIDs) {
+      Zotero.MenuManager?.unregisterMenu(menuID);
+    }
+    addon.data.registeredMenuIDs = [];
   }
 }

--- a/src/modules/CustomResolver.ts
+++ b/src/modules/CustomResolver.ts
@@ -1,26 +1,52 @@
 // https://www.zotero.org/support/kb/custom_pdf_resolvers
 // https://github.com/zotero/zotero/blob/5536f8d2bd08ddac9074b9df05b7d205273835e7/chrome/content/zotero/xpcom/attachments.js#L1350
 export interface CustomResolver {
-  name: string,
-  method: "GET" | "POST",
-  url: string,  // must include {doi}
-  mode: "html" | "json",
-  selector: string,
-  automatic?: boolean,
+  name: string;
+  method: "GET" | "POST";
+  url: string; // must include {doi}
+  mode: "html" | "json";
+  selector: string;
+  automatic?: boolean;
 
   // HTML
-  attribute?: string,
-  index?: number,
+  attribute?: string;
+  index?: number;
 
   // JSON
   mappings?: {
-    url?: string,
-    pageURL?: string,
-  },
+    url?: string;
+    pageURL?: string;
+  };
+}
+
+export const defaultSciHubURLs = [
+  "https://sci-hub.ru/",
+  "https://sci-hub.st/",
+  "https://sci-hub.su/",
+  "https://sci-hub.box/",
+  "https://sci-hub.red/",
+] as const;
+
+const obsoleteDefaultSciHubURLs = [
+  "https://sci-hub.se/",
+  "https://sci-hub.ren/",
+  "https://sci-hub.ee/",
+] as const;
+
+export function isObsoleteDefaultSciHubResolver(resolver: CustomResolver) {
+  return (
+    resolver.name === "Sci-Hub" &&
+    resolver.method === "GET" &&
+    resolver.mode === "html" &&
+    resolver.selector === "#pdf" &&
+    resolver.attribute === "src" &&
+    obsoleteDefaultSciHubURLs.some((url) => resolver.url === `${url}{doi}`)
+  );
 }
 
 export function isCustomResolverEqual(a: CustomResolver, b: CustomResolver) {
-  return a.name === b.name &&
+  return (
+    a.name === b.name &&
     a.method === b.method &&
     a.url === b.url &&
     a.mode === b.mode &&
@@ -29,14 +55,22 @@ export function isCustomResolverEqual(a: CustomResolver, b: CustomResolver) {
     a.attribute === b.attribute &&
     a.index === b.index &&
     a.mappings?.url === b.mappings?.url &&
-    a.mappings?.pageURL === b.mappings?.pageURL;
+    a.mappings?.pageURL === b.mappings?.pageURL
+  );
 }
 
-export function sciHubCustomResolver(url: string, automatic = true): CustomResolver {
+export function sciHubCustomResolver(
+  url: string,
+  automatic = true,
+): CustomResolver {
   return {
     name: "Sci-Hub",
     method: "GET",
-    url: url.includes('{doi}') ? url : url.endsWith('/') ? `${url}{doi}` : `${url}/{doi}`,
+    url: url.includes("{doi}")
+      ? url
+      : url.endsWith("/")
+        ? `${url}{doi}`
+        : `${url}/{doi}`,
     mode: "html",
     selector: "#pdf",
     attribute: "src",
@@ -44,17 +78,10 @@ export function sciHubCustomResolver(url: string, automatic = true): CustomResol
   };
 }
 
-export function presetSciHubCustomResolvers(automatic = true): Readonly<Readonly<CustomResolver>[]> {
-  const scihubURLs = [
-    'https://sci-hub.se/',
-    'https://sci-hub.st/',
-    'https://sci-hub.ru/',
-    'https://sci-hub.box/',
-    'https://sci-hub.red/',
-    'https://sci-hub.ren/',
-    'https://sci-hub.ee/',
-  ]
-  return scihubURLs.map(url => {
+export function presetSciHubCustomResolvers(
+  automatic = true,
+): Readonly<Readonly<CustomResolver>[]> {
+  return defaultSciHubURLs.map((url) => {
     return {
       name: "Sci-Hub",
       method: "GET",

--- a/src/modules/CustomResolverManager.ts
+++ b/src/modules/CustomResolverManager.ts
@@ -4,53 +4,109 @@ import { CustomResolver, isCustomResolverEqual } from "./CustomResolver";
 
 export class CustomResolverManager {
   private static _shared?: CustomResolverManager;
-  private static zoteroCustomResolversPrefKey: Readonly<string> = 'extensions.zotero.findPDFs.resolvers';
-  private static customResolversPrefKey: Readonly<string> = 'resolvers';
-  private static customResolversLargerPrefKey: Readonly<string> = 'userCustomResolvers';
+  private static zoteroCustomResolversPrefKey: Readonly<string> =
+    "extensions.zotero.findPDFs.resolvers";
+  private static customResolversPrefKey: Readonly<string> = "resolvers";
+  private static customResolversLargerPrefKey: Readonly<string> =
+    "userCustomResolvers";
   static get shared() {
-    if (!this._shared) { this._shared = new CustomResolverManager(); }
+    if (!this._shared) {
+      this._shared = new CustomResolverManager();
+    }
     return this._shared;
   }
 
   // user custom resolvers
-  private prefs = new LargePrefHelper(CustomResolverManager.customResolversLargerPrefKey, config.prefsPrefix, 'parser');
+  private prefs = new LargePrefHelper(
+    CustomResolverManager.customResolversLargerPrefKey,
+    config.prefsPrefix,
+    "parser",
+  );
   get customResolvers() {
-    return this.prefs.getValue(CustomResolverManager.customResolversPrefKey) as CustomResolver[] ?? [];
+    const resolvers = this.prefs.getValue(
+      CustomResolverManager.customResolversPrefKey,
+    );
+    return Array.isArray(resolvers) ? (resolvers as CustomResolver[]) : [];
   }
   private set customResolvers(value: CustomResolver[]) {
     this.prefs.setValue(CustomResolverManager.customResolversPrefKey, value);
   }
 
   // system custom resolvers
-  appendCustomResolversInZotero(resolvers: CustomResolver[] | Readonly<CustomResolver[]>) {
-    this.customResolversInZotero = this.customResolversInZotero.concat(resolvers.filter(value => this.customResolversInZotero.findIndex(e => isCustomResolverEqual(e, value)) < 0))
-    this.customResolvers = this.customResolvers.concat(resolvers.filter(value => this.customResolvers.findIndex(e => isCustomResolverEqual(e, value)) < 0))
+  appendCustomResolversInZotero(
+    resolvers: CustomResolver[] | Readonly<CustomResolver[]>,
+  ) {
+    this.customResolversInZotero = this.customResolversInZotero.concat(
+      resolvers.filter(
+        (value) =>
+          this.customResolversInZotero.findIndex((e) =>
+            isCustomResolverEqual(e, value),
+          ) < 0,
+      ),
+    );
+    this.customResolvers = this.customResolvers.concat(
+      resolvers.filter(
+        (value) =>
+          this.customResolvers.findIndex((e) =>
+            isCustomResolverEqual(e, value),
+          ) < 0,
+      ),
+    );
   }
   removeCustomResolversInZotero(resolvers: CustomResolver[]) {
-    this.customResolversInZotero = this.customResolversInZotero.filter(value => !resolvers.find(e => isCustomResolverEqual(e, value)));
-    this.customResolvers = this.customResolvers.filter(value => !resolvers.find(e => isCustomResolverEqual(e, value)));
+    this.customResolversInZotero = this.customResolversInZotero.filter(
+      (value) => !resolvers.find((e) => isCustomResolverEqual(e, value)),
+    );
+    this.customResolvers = this.customResolvers.filter(
+      (value) => !resolvers.find((e) => isCustomResolverEqual(e, value)),
+    );
   }
   removeAllCustomResolversInZotero() {
     this.removeCustomResolversInZotero(this.customResolvers);
   }
+  removeCustomResolversMatching(
+    predicate: (resolver: CustomResolver) => boolean,
+  ) {
+    this.customResolversInZotero = this.customResolversInZotero.filter(
+      (value) => !predicate(value),
+    );
+    this.customResolvers = this.customResolvers.filter(
+      (value) => !predicate(value),
+    );
+  }
   private get customResolversInZotero() {
-    const values = Zotero.Prefs.get(CustomResolverManager.zoteroCustomResolversPrefKey, true);
-    if (typeof values !== 'string') { return []; }
-    let result = JSON.parse(values);
+    const values = Zotero.Prefs.get(
+      CustomResolverManager.zoteroCustomResolversPrefKey,
+      true,
+    );
+    if (typeof values !== "string") {
+      return [];
+    }
+    let result;
+    try {
+      result = JSON.parse(values);
+    } catch {
+      ztoolkit.log("Invalid Zotero custom PDF resolvers preference.");
+      return [];
+    }
     if (!Array.isArray(result)) {
       result = [result];
     }
     return result as CustomResolver[];
   }
   private set customResolversInZotero(resolvers: CustomResolver[]) {
-    Zotero.Prefs.set(CustomResolverManager.zoteroCustomResolversPrefKey, JSON.stringify(resolvers), true);
+    Zotero.Prefs.set(
+      CustomResolverManager.zoteroCustomResolversPrefKey,
+      JSON.stringify(resolvers),
+      true,
+    );
   }
-
 
   private init() {
-    this.customResolvers = this.customResolvers.filter(value => this.customResolversInZotero.findIndex(e => isCustomResolverEqual(e, value)));
+    this.customResolvers = this.customResolvers.filter((value) =>
+      this.customResolversInZotero.findIndex((e) =>
+        isCustomResolverEqual(e, value),
+      ),
+    );
   }
-
-
-
 }

--- a/src/modules/SciHubFetcher.ts
+++ b/src/modules/SciHubFetcher.ts
@@ -1,5 +1,6 @@
 import { getString } from "../utils/locale";
 import { Utils } from "../utils/utils";
+import { defaultSciHubURLs } from "./CustomResolver";
 import { CustomResolverManager } from "./CustomResolverManager";
 
 class PDFNotFoundError extends Error {
@@ -113,10 +114,10 @@ export class SciHubFetcher {
   private static get baseSciHubURLs(): string[] {
     const resolvers = CustomResolverManager.shared.customResolvers;
     if (resolvers.length <= 0) {
-      return ["https://sci-hub.se/"];
+      return [...defaultSciHubURLs];
     }
     return resolvers.map((r) => {
-      // resolver.url is like "https://sci-hub.se/{doi}", extract the base
+      // resolver.url is like "https://sci-hub.ru/{doi}", extract the base
       return r.url.replace(/\{doi\}.*$/, "");
     });
   }

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -12,38 +12,56 @@ export async function registerPrefsScripts(_window: Window) {
   } else {
     addon.data.prefs.window = _window;
   }
-  const autoDownloadCheckbox = _window.document.querySelector(`#zotero-prefpane-${config.addonRef}-autoDownload`) as XUL.Checkbox;
-  const urlInput = _window.document.querySelector(`#zotero-prefpane-${config.addonRef}-scihubUrl`) as HTMLInputElement;
+  const autoDownloadCheckbox = _window.document.querySelector(
+    `#zotero-prefpane-${config.addonRef}-autoDownload`,
+  ) as XUL.Checkbox | null;
+  const urlInput = _window.document.querySelector(
+    `#zotero-prefpane-${config.addonRef}-scihubUrl`,
+  ) as HTMLInputElement | null;
+
+  if (!autoDownloadCheckbox || !urlInput) {
+    ztoolkit.log("Preference controls were not found.");
+    return;
+  }
 
   const resolver = CustomResolverManager.shared.customResolvers;
-  autoDownloadCheckbox.checked = resolver.length > 0 && resolver[0].automatic !== false;
-  urlInput.value = resolver.map((e) => e.url).join(';');
+  autoDownloadCheckbox.checked =
+    resolver.length > 0 && resolver[0].automatic !== false;
+  urlInput.value = resolver.map((e) => e.url).join(";");
 
   const validURL = (url?: string) => {
-    return url && url.length > 0;
+    return !!url && url.length > 0;
   };
   const updateResolver = () => {
     CustomResolverManager.shared.removeAllCustomResolversInZotero();
-    const urls = urlInput.value.split(/\s*[;,，；、\s]\s*/);
+    const urls = urlInput.value
+      .split(/\s*[;,，；、\s]\s*/)
+      .map((url) => url.trim())
+      .filter(Boolean);
     const setedURLs: string[] = [];
     for (const url of new Set(urls)) {
-      if (validURL(url.trim())) {
-        const resolver = sciHubCustomResolver(url.trim(), autoDownloadCheckbox.checked);
+      if (validURL(url)) {
+        const resolver = sciHubCustomResolver(
+          url,
+          autoDownloadCheckbox.checked,
+        );
         CustomResolverManager.shared.appendCustomResolversInZotero([resolver]);
         setedURLs.push(resolver.url);
       } else {
         new ztoolkit.ProgressWindow(config.addonName, {
           closeOnClick: true,
           closeTime: 3000,
-        }).createLine({
-          text: `URL Error`,
-          type: 'fail',
-          progress: 0
-        }).show();
+        })
+          .createLine({
+            text: `URL Error`,
+            type: "fail",
+            progress: 0,
+          })
+          .show();
       }
     }
-    urlInput.value = setedURLs.join(',');
-  }
+    urlInput.value = setedURLs.join(",");
+  };
   autoDownloadCheckbox.addEventListener("command", () => {
     updateResolver();
   });

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "zotero-plugin-scaffold";
+import { resolve } from "node:path";
 import pkg from "./package.json";
+
+const srcEntry = resolve("src/index.ts").replace(/\\/g, "/");
 
 export default defineConfig({
   source: ["src", "addon"],
@@ -28,12 +31,12 @@ export default defineConfig({
     },
     esbuildOptions: [
       {
-        entryPoints: ["src/index.ts"],
+        entryPoints: [srcEntry],
         define: {
           __env__: `"${process.env.NODE_ENV}"`,
         },
         bundle: true,
-        target: "firefox115",
+        target: "firefox140",
         outfile: `.scaffold/build/addon/content/scripts/${pkg.config.addonRef}.js`,
       },
     ],
@@ -42,7 +45,7 @@ export default defineConfig({
     bumpp: {
       commit: "chore(publish): release V%s",
       tag: "V%s",
-    }
+    },
   },
 
   test: {


### PR DESCRIPTION
## Summary

- Update the add-on manifest and build target for Zotero 9 / Firefox 140.
- Register the item context menu through `Zotero.MenuManager` while preserving the menu icon.
- Load the PDF Download preferences pane through `PreferencePanes.register({ scripts })` and guard against malformed resolver preferences.
- Refresh the default Sci-Hub resolver list and remove obsolete built-in defaults from existing installs.

## Validation

- `npm run build`
- `git diff --check`
- `npx prettier --check README.md doc/README-zhCN.md addon/content/preferences.xhtml addon/content/scripts/preferences.js src/addon.ts src/hooks.ts src/modules/Common.ts src/modules/CustomResolver.ts src/modules/CustomResolverManager.ts src/modules/SciHubFetcher.ts src/modules/preferenceScript.ts zotero-plugin.config.ts`
- `npx eslint src/addon.ts src/hooks.ts src/modules/Common.ts src/modules/CustomResolver.ts src/modules/CustomResolverManager.ts src/modules/SciHubFetcher.ts src/modules/preferenceScript.ts zotero-plugin.config.ts`